### PR TITLE
1.6002: Added constants and enums.

### DIFF
--- a/std_zh/std_constants.zh
+++ b/std_zh/std_constants.zh
@@ -1,5 +1,5 @@
 // std_constants.zh
-// 14th July, 2019 for ZC 2.55 Alpha 26
+// 18th July, 2019 for ZC 2.55 Alpha 28
 // Contains required constants for std.zh and ZScript functions.
 
 typedef const int define;
@@ -1515,6 +1515,79 @@ const int FONT_TRS		= 67;
 const int FONT_Z2		= 68;	//Zelda 2 plus custom lowercase.
 const int FONT_LISA		= 69;	//Lisa OS System Font
 
+//Font heights, in pixels, for the above fonts:
+define FONT_Z1_HEIGHT = 8;
+define FONT_Z3_HEIGHT = 16;
+define FONT_Z3SMALL_HEIGHT = 6;
+define FONT_DEF_HEIGHT = 8;
+define FONT_L_HEIGHT = 13;
+define FONT_L2_HEIGHT = 13;
+define FONT_P_HEIGHT = 8;
+define FONT_MATRIX_HEIGHT = 8;
+define FONT_ZTIME_HEIGHT = 6;
+define FONT_S_HEIGHT = 6;
+define FONT_S2_HEIGHT = 6;
+define FONT_SP_HEIGHT = 6;
+define FONT_SUBSCREEN1_HEIGHT = 8;
+define FONT_SUBSCREEN2_HEIGHT = 8;
+define FONT_SUBSCREEN3_HEIGHT = 8;
+define FONT_SUBSCREEN4_HEIGHT = 8;
+define FONT_GBLA_HEIGHT = 8;
+define FONT_LA_HEIGHT = 8;
+define FONT_GORON_HEIGHT = 15;
+define FONT_ZORAN_HEIGHT = 15;
+define FONT_HYLIAN1_HEIGHT = 15;
+define FONT_HYLIAN2_HEIGHT = 24;
+define FONT_HYLIAN3_HEIGHT = 21;
+define FONT_HYLIAN4_HEIGHT = 18;
+define FONT_GBORACLE_HEIGHT = 15;
+define FONT_GBORACLEP_HEIGHT = 15;
+define FONT_DSPHANTOM_HEIGHT = 15;
+define FONT_DSPHANTOMP_HEIGHT = 15;
+define FONT_ATARI800_HEIGHT = 16;
+define FONT_ACORN_HEIGHT = 8;
+define FONT_ADOS_HEIGHT = 8;
+define FONT_ALLEGRO_HEIGHT = 8;
+define FONT_APPLE2_HEIGHT = 8;
+define FONT_APPLE2_80COL_HEIGHT = 16;
+define FONT_APPLE2GS_HEIGHT = 12;
+define FONT_AQUARIUS_HEIGHT = 8;
+define FONT_ATARI400_HEIGHT = 8;
+define FONT_C64_HEIGHT = 8;
+define FONT_C64_HIRES_HEIGHT = 16;
+define FONT_CGA_HEIGHT = 8;
+define FONT_COCO_HEIGHT = 16;
+define FONT_COCO2_HEIGHT = 16;
+define FONT_COUPE_HEIGHT = 8;
+define FONT_CPC_HEIGHT = 12;
+define FONT_FANTASY_HEIGHT = 18;
+define FONT_FDS_KANA_HEIGHT = 8;
+define FONT_FDSLIKE_HEIGHT = 8;
+define FONT_FDS_ROMAN_HEIGHT = 8;
+define FONT_FF_HEIGHT = 8;
+define FONT_FUTHARK_HEIGHT = 8;
+define FONT_GAIA_HEIGHT = 16;
+define FONT_HIRA_HEIGHT = 8;
+define FONT_JP_HEIGHT = 16;
+define FONT_KONG_HEIGHT = 8;
+define FONT_MANA_HEIGHT = 12;
+define FONT_MARIOLAND_HEIGHT = 8;
+define FONT_MOT_HEIGHT = 12;
+define FONT_MSX0_HEIGHT = 8;
+define FONT_MSX1_HEIGHT = 8;
+define FONT_PET_HEIGHT = 8;
+define FONT_PSTART_HEIGHT = 8;
+define FONT_SATURN_HEIGHT = 16;
+define FONT_SCIFI_HEIGHT = 8;
+define FONT_SHERWOOD_HEIGHT = 16;
+define FONT_SINQL_HEIGHT = 8;
+define FONT_SPECTRUM_HEIGHT = 8;
+define FONT_SPECTRUM_LG_HEIGHT = 16;
+define FONT_TI99_HEIGHT = 8;
+define FONT_TRS_HEIGHT = 16;
+define FONT_Z2_HEIGHT = 8;
+define FONT_LISA_HEIGHT = 8;
+
 // PrintString Text Formats. Use with Screen->DrawString.
 const int TF_NORMAL             = 0; // treats the left-most char as (x)
 const int TF_CENTERED           = 1; // prints the string centered on (x)
@@ -2119,6 +2192,7 @@ const int FFCBF_ETHEREAL        	= 0x200;
 const int FFCBF_IGNOREHOLDUP    	= 0x400;
 const int FFCBF_IGNORECHANGER   	= 0x800;
 const int FFCBF_IMPRECISIONCHANGER    	= 0x1000;
+const int FFCBF_LENSINVIS	   	= 0x2000;
 
 
 //Aim-type constants, for use with AimEWeapon
@@ -2647,3 +2721,46 @@ enum
     MIDI_DUNGEON,
     MIDI_LEVEL9 //==0, cannot be played by 'Audio->PlayMIDI'
 };
+
+
+
+enum linkspritetype { LSprwalkspr, LSprstabspr, LSprslashspr, LSprfloatspr, 
+	LSprswimspr, LSprdivespr, LSprpoundspr,
+LSprjumpspr, LSprchargespr, LSprcastingspr, 
+	LSprholdspr1, LSprholdspr2, LSprholdsprw1, LSprholdsprw2, LSprlast };
+
+	
+
+//suspend types
+enum { 
+	//Typical processes that we want to pause, similar to ALLOFF()
+	
+	//0 : Combo animation
+	susptCOMBOANIM,
+	
+	//1->5 Main Sprite animation by type
+	susptGUYS, susptLWEAPONS, susptEWEAPONS, susptITEMS, susptLINK, 
+	
+	//6 : FFC (e.g. movement, changers, but not scripts)
+	susptUPDATEFFC, //ffcs
+	
+	//7->8 : Sprite subclasses
+	susptDECORATIONS, susptPARTICLES, //sprite subclasses
+	
+	//9->10: Palette events
+	susptPALCYCLE, susptLAKES, //lake dries up
+	
+	//11->15 : game system events
+	susptCOLLISIONS, susptCONTROLSTATE, susptONEFRAMECONDS, susptSCRIPDRAWCLEAR, susptQUAKE,
+
+	//16->26 Script Types
+	susptGLOBALGAME, susptNPCSCRIPTS, susptLWEAPONSCRIPTS, susptEWEAPONSCRIPTS, susptITEMSPRITESCRIPTS,
+	susptFFCSCRIPTS, susptLINKACTIVE, susptITEMSCRIPTENGINE, susptDMAPSCRIPT, susptSCREENSCRIPTS,
+	susptSUBSCREENSCRIPTS, //26
+	
+	//27->29 : Moving items
+	susptCONVEYORSITEMS, susptDRAGGINGITEM, susptROAMINGITEM,
+	//30->34 : Misc
+	susptLENS, susptHOOKSHOT, susptMOVINGBLOCKS, susptMAGICCAST, susptSCREENDRAW,
+	//35
+	susptLAST };

--- a/std_zh/std_vars.zh
+++ b/std_zh/std_vars.zh
@@ -1,11 +1,11 @@
 //General-Use Arrays with Getter/Setter functions
-///14th July, 2019
+///17th July, 2019
 
 //A generic array, pre-included with all quests. 
 //float stdArray[4096]; //This should be called GlobalRAM[]
 int std_zh___GlobalRAM[4096];
 
-const float STD_VERSION = 1.6001;
+const float STD_VERSION = 1.6002;
 float __stdzh_getVersion() { return STD_VERSION; }
 
 //! Because this is the first global array that will likely be declared, called from the 'import "std.zh"' 


### PR DESCRIPTION
Changelog: Added font height constants.
Added mapdata->FFCFlags[32] constant for Invisible to Lens
Added Link Sprite Type enum for Link->GetOriginalTile(linkspritetype,int dir)
Added enum for Game->Suspend indices.
	Note: Indices higher than susptSUBSCREENSCRIPTS aren't officially supported and
	exist purely for testing purposes.